### PR TITLE
(fix) Fix the version of apparun in the dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "kaleido",
     "tqdm",
     "ruamel.yaml",
-    "apparun==0.3.1",
+    "apparun==0.3.0",
     "pre-commit",
     "typer==0.15.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "kaleido",
     "tqdm",
     "ruamel.yaml",
-    "apparun==0.3.0",
+    "apparun==0.3.2",
     "pre-commit",
     "typer==0.15.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ aenum
 kaleido
 tqdm
 ruamel.yaml
-apparun==0.3.0
+apparun==0.3.2
 pre-commit
 hatchling


### PR DESCRIPTION
Fix the version needed for apparun from 0.3.0 to 0.3.2 in the pyproject.toml file and in the requirements.txt file.