### PR TITLE
(feature) Make the use of EcoInvent database optional

### DIFF
--- a/appabuild/setup.py
+++ b/appabuild/setup.py
@@ -27,20 +27,22 @@ def initialize(appabuild_config_path: str) -> ForegroundDatabase:
     with open(appabuild_config_path, "r") as stream:
         appabuild_config = yaml.safe_load(stream)
 
-    print(appabuild_config)
+    ecoinvent_name = (
+        appabuild_config["databases"]["ecoinvent"]["name"]
+        if "ecoinvent" in appabuild_config["databases"]
+        else None
+    )
+
+    ecoinvent_path = (
+        appabuild_config["databases"]["ecoinvent"]["path"]
+        if "ecoinvent" in appabuild_config["databases"]
+        else None
+    )
 
     return project_setup(
         project_name=appabuild_config["project_name"],
-        ecoinvent_name=(
-            appabuild_config["databases"]["ecoinvent"]["name"]
-            if "ecoinvent" in appabuild_config["databases"]
-            else None
-        ),
-        ecoinvent_path=(
-            appabuild_config["databases"]["ecoinvent"]["path"]
-            if "ecoinvent" in appabuild_config["databases"]
-            else None
-        ),
+        ecoinvent_name=ecoinvent_name,
+        ecoinvent_path=ecoinvent_path,
         foreground_name=appabuild_config["databases"]["foreground"]["name"],
         foreground_path=appabuild_config["databases"]["foreground"]["path"],
     )

--- a/appabuild/setup.py
+++ b/appabuild/setup.py
@@ -1,6 +1,7 @@
 """
 Setup everything required to build an ImpactModel
 """
+
 from typing import Optional
 
 import brightway2 as bw
@@ -9,8 +10,8 @@ import yaml
 from appabuild.database.databases import (
     BiosphereDatabase,
     EcoInventDatabase,
-    ImpactProxiesDatabase,
     ForegroundDatabase,
+    ImpactProxiesDatabase,
 )
 from appabuild.model.builder import ImpactModelBuilder
 
@@ -26,16 +27,28 @@ def initialize(appabuild_config_path: str) -> ForegroundDatabase:
     with open(appabuild_config_path, "r") as stream:
         appabuild_config = yaml.safe_load(stream)
 
+    print(appabuild_config)
+
     return project_setup(
         project_name=appabuild_config["project_name"],
-        ecoinvent_name=appabuild_config["databases"]["ecoinvent"]["name"],
-        ecoinvent_path=appabuild_config["databases"]["ecoinvent"]["path"],
+        ecoinvent_name=(
+            appabuild_config["databases"]["ecoinvent"]["name"]
+            if "ecoinvent" in appabuild_config["databases"]
+            else None
+        ),
+        ecoinvent_path=(
+            appabuild_config["databases"]["ecoinvent"]["path"]
+            if "ecoinvent" in appabuild_config["databases"]
+            else None
+        ),
         foreground_name=appabuild_config["databases"]["foreground"]["name"],
         foreground_path=appabuild_config["databases"]["foreground"]["path"],
     )
 
 
-def build(lca_config_path: str, foreground_database: Optional[ForegroundDatabase] = None):
+def build(
+    lca_config_path: str, foreground_database: Optional[ForegroundDatabase] = None
+):
     """
     Build an impact model for the configured functional unit and save it to the disk (to the location configured in the file).
     :param lca_config_path: information about the current LCA, such as functional unit,
@@ -49,19 +62,18 @@ def build(lca_config_path: str, foreground_database: Optional[ForegroundDatabase
     impact_model = impact_model_builder.build_impact_model(foreground_database)
 
     impact_model.to_yaml(
-        impact_model_builder.output_path,
-        impact_model_builder.compile_models
+        impact_model_builder.output_path, impact_model_builder.compile_models
     )
 
     return impact_model
 
 
 def project_setup(
-        project_name: str,
-        ecoinvent_name: str,
-        ecoinvent_path: str,
-        foreground_name: str,
-        foreground_path: str,
+    project_name: str,
+    foreground_name: str,
+    foreground_path: str,
+    ecoinvent_name: Optional[str] = None,
+    ecoinvent_path: Optional[str] = None,
 ) -> ForegroundDatabase:
     """
     Triggers all Brightway functions and database import necessary to build an Impact
@@ -73,17 +85,21 @@ def project_setup(
     :param foreground_path: path to folder containing user datasets.
     """
     bw.projects.set_current(project_name)
+    foreground_database = ForegroundDatabase(
+        name=foreground_name,
+        path=foreground_path,
+    )
     databases = [
         BiosphereDatabase(),
         ImpactProxiesDatabase(),
-        EcoInventDatabase(name=ecoinvent_name, path=ecoinvent_path),
-        ForegroundDatabase(
-            name=foreground_name,
-            path=foreground_path,
-        ),
+        foreground_database,
     ]
+
+    if ecoinvent_path is not None:
+        ecoinvent_database = EcoInventDatabase(name=ecoinvent_name, path=ecoinvent_path)
+        databases.append(ecoinvent_database)
 
     for external_database in databases:
         external_database.execute_at_startup()
 
-    return databases[3]
+    return foreground_database


### PR DESCRIPTION
EcoInvent database is now optional so that appabuild can be used without it.