### PR TITLE
(Fix) Fix dependencies versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "apparun==0.3.2",
     "pre-commit",
     "typer==0.15.1",
-    "ipython==8.34.0",
+    "ipython>=7.6.0,<=8.34.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ kaleido
 tqdm
 ruamel.yaml
 apparun==0.3.2
-ipython==8.34.0
+ipython<=8.34.0
 pre-commit
 hatchling

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ kaleido
 tqdm
 ruamel.yaml
 apparun==0.3.2
-ipython<=8.34.0
+ipython>=7.6.0,<=8.34.0
 pre-commit
 hatchling


### PR DESCRIPTION
Fix the version of the dependency package IPython.
The new version 9.0.0 of IPython make Appa Build crash every time.
Appa Build need a version for IPython between 7.6.0 and 8.34.0.