### PR TITLE
(fix) Add mermaid-py in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ ipython>=7.6.0,<=8.34.0
 pre-commit
 hatchling
 click==8.1.8
+mermaid-py==0.7.1


### PR DESCRIPTION
Package mermaid-py was present in pyproject.toml but not requirements.txt