### PR TITLE
(fix) Fix log system

### DIFF
--- a/appabuild/logger.py
+++ b/appabuild/logger.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from pydantic import ValidationError
 
-logger = logging.getLogger("appabuild")
+logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.DEBUG)
 
 # Format the message in the logs


### PR DESCRIPTION
Fix the log system where Appa Run was creating its own log file instead of using the log file of Appa Build.