### PR TITLE
(fix) Freeze peewee version due to import error with latest ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dependencies = [
     "ruamel.yaml",
     "typer==0.15.1",
     "ipython>=7.6.0,<=8.34.0",
-    "mermaid-py==0.7.1"
+    "mermaid-py==0.7.1",
+    "peewee==3.18.2"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ pre-commit
 hatchling
 click==8.1.8
 mermaid-py==0.7.1
+peewee==3.18.2


### PR DESCRIPTION
Freeze peewee version (3.18.2) due to import error with latest ones