### PR TITLE
(fix) correct validate_expr false positives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "apparun>=0.4.3",
+    "apparun>=0.4.5",
     "click<=8.1.8",
     "numpy==1.26.4",
     "pyarrow==22.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apparun>=0.4.3
+apparun>=0.4.5
 numpy
 pyarrow
 pandas

--- a/tests/data/cmd_build/die_shrunk_lca_conf.yaml
+++ b/tests/data/cmd_build/die_shrunk_lca_conf.yaml
@@ -1,0 +1,52 @@
+scope:
+  fu:
+    name: 'die_shrunk'
+    database: "user_database"
+  methods:
+    - "EFV3_CLIMATE_CHANGE"
+model:
+  path: "."
+  name: "die_shrunk"
+  compile: True
+  metadata:
+    author:
+      name: Maxime PERALTA
+      organization: CEA
+      mail: maxime.peralta@cea.fr
+    reviewer:
+      name: Mathias TORCASO
+      organization: CEA
+      mail:
+    report:
+      link: https://appalca.github.io/
+      description: ""
+      date: 15/07/2026
+      version: "1"
+      license: proprietary
+      appabuild_version: "0.4.3"
+  parameters:
+    - name: die_area
+      type: float
+      default: 10
+      min: 1
+      max: 100
+    - name: fab_location
+      type: enum
+      default: TW
+      weights:
+        TW: 1
+    - name: die_defect_density
+      type: float
+      default: 0.0005
+      min: 0.0001
+      max: 0.001
+    - name: die_node
+      type: float
+      default: 28
+      min: 5
+      max: 90
+    - name: die_shrink_factor
+      type: float
+      default: 0.9
+      min: 0.8
+      max: 1

--- a/tests/data/cmd_build/foreground_datasets/die_shrunk.yaml
+++ b/tests/data/cmd_build/foreground_datasets/die_shrunk.yaml
@@ -1,0 +1,24 @@
+name: die_shrunk
+location: GLO
+type: process
+unit: unit
+amount: 1
+parameters:
+- die_area
+- die_shrink_factor
+- die_defect_density
+- die_node
+include_in_tree: True
+comment: ""
+exchanges:
+- database: user_database
+  name: soc_die_manufacturing
+  type: technosphere
+  parameters_matching:
+    area: die_area*die_shrink_factor*die_shrink_factor
+    technology_node: die_node
+    defect_density: die_defect_density
+  amount: 1
+  input:
+    database: user_database
+    uuid: functional_logic_die_manufacturing

--- a/tests/data/cmd_build/functional_logic_die_manufacturing_lca_conf.yaml
+++ b/tests/data/cmd_build/functional_logic_die_manufacturing_lca_conf.yaml
@@ -1,0 +1,47 @@
+scope:
+  fu:
+    name: 'functional_logic_die_manufacturing'
+    database: "user_database"
+  methods:
+    - "EFV3_CLIMATE_CHANGE"
+model:
+  path: "."
+  name: "functional_logic_die_manufacturing"
+  compile: True
+  metadata:
+    author:
+      name: Maxime PERALTA
+      organization: CEA
+      mail: maxime.peralta@cea.fr
+    reviewer:
+      name: Mathias TORCASO
+      organization: CEA
+      mail:
+    report:
+      link: https://appalca.github.io/
+      description: ""
+      date: 15/07/2026
+      version: "1"
+      license: proprietary
+      appabuild_version: "0.4.3"
+  parameters:
+    - name: area
+      type: float
+      default: 10
+      min: 1
+      max: 100
+    - name: fab_location
+      type: enum
+      default: TW
+      weights:
+        TW: 1
+    - name: defect_density
+      type: float
+      default: 0.0005
+      min: 0.0001
+      max: 0.001
+    - name: technology_node
+      type: float
+      default: 28
+      min: 5
+      max: 90

--- a/tests/end_to_end/test_symbolic_expr.py
+++ b/tests/end_to_end/test_symbolic_expr.py
@@ -1,0 +1,43 @@
+"""
+Some symbolic expressions are not properly recreated after serialization/deserialization.
+These tests assert that the fixes are properly
+"""
+
+import os
+
+import pytest
+import yaml
+from apparun.impact_model import ImpactModel
+from pydantic import ValidationError
+from typer.testing import CliRunner
+
+from appabuild.cli.lca import build
+from tests import DATA_DIR
+
+runner = CliRunner()
+
+
+def test_build_minus_param():
+    appaconf_file = os.path.join(DATA_DIR, "cmd_build", "appalca_conf_wo_ei.yaml")
+    conf_file = os.path.join(
+        DATA_DIR, "cmd_build", "functional_logic_die_manufacturing_lca_conf.yaml"
+    )
+    build(appaconf_file, conf_file)
+
+    try:
+        model = ImpactModel.from_yaml("functional_logic_die_manufacturing.yaml")
+        model.get_scores()
+    except ValidationError:
+        pytest.fail("-param in a symbolic expression is valid")
+
+
+def test_abs():
+    appaconf_file = os.path.join(DATA_DIR, "cmd_build", "appalca_conf_wo_ei.yaml")
+    conf_file = os.path.join(DATA_DIR, "cmd_build", "die_shrunk_lca_conf.yaml")
+    build(appaconf_file, conf_file)
+
+    try:
+        model = ImpactModel.from_yaml("die_shrunk.yaml")
+        model.get_scores()
+    except ValidationError:
+        pytest.fail("Abs() in a symbolic expression is valid")


### PR DESCRIPTION
Fixed in `apparun==0.4.5`:

- `validate_expr` allows sympy functions
- `validate_expr` allows `(` before an operator (which can happen when `-1*param` is shortened to `-param`)